### PR TITLE
Updating external data API

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12,7 +12,7 @@
         "@types/react": "18.0.25",
         "@types/react-dom": "18.0.9",
         "coi-serviceworker": "^0.1.6",
-        "coinflip-executor-contract": "0.3.1",
+        "coinflip-executor-contract": "0.4.1",
         "eslint": "8.28.0",
         "eslint-config-next": "13.0.5",
         "next": "13.0.5",
@@ -752,9 +752,9 @@
       "integrity": "sha512-STWJBMdxuKvvzbd3G1+sFrV5Ia+UDv5lP2CVCx+kEfqghOSb8nzcG/ttpSV2k/haTUn5OsfTAlkK+uFkKBqBqw=="
     },
     "node_modules/coinflip-executor-contract": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/coinflip-executor-contract/-/coinflip-executor-contract-0.3.1.tgz",
-      "integrity": "sha512-3uNAT7NG9AdFUXxnVQRSHS2fqmZRKCknWB+9ODMm1DBScHtIozkz+vTcyVYLeLSObGsLk8/j0CxIFml97Bo6Qg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/coinflip-executor-contract/-/coinflip-executor-contract-0.4.1.tgz",
+      "integrity": "sha512-KS8/BktVt7V8Ps5yo+rxUAs/KVfrSgU84DQHbSn/+i11tmTJSsEYqCkvUJNZn2+g9pjaqmXRDIFV6aTWkahAGg==",
       "peerDependencies": {
         "snarkyjs": "^0.7.3"
       }
@@ -3593,9 +3593,9 @@
       "integrity": "sha512-STWJBMdxuKvvzbd3G1+sFrV5Ia+UDv5lP2CVCx+kEfqghOSb8nzcG/ttpSV2k/haTUn5OsfTAlkK+uFkKBqBqw=="
     },
     "coinflip-executor-contract": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/coinflip-executor-contract/-/coinflip-executor-contract-0.3.1.tgz",
-      "integrity": "sha512-3uNAT7NG9AdFUXxnVQRSHS2fqmZRKCknWB+9ODMm1DBScHtIozkz+vTcyVYLeLSObGsLk8/j0CxIFml97Bo6Qg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/coinflip-executor-contract/-/coinflip-executor-contract-0.4.1.tgz",
+      "integrity": "sha512-KS8/BktVt7V8Ps5yo+rxUAs/KVfrSgU84DQHbSn/+i11tmTJSsEYqCkvUJNZn2+g9pjaqmXRDIFV6aTWkahAGg==",
       "requires": {}
     },
     "color-convert": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,7 @@
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.9",
     "coi-serviceworker": "^0.1.6",
-    "coinflip-executor-contract": "0.3.1",
+    "coinflip-executor-contract": "0.4.1",
     "eslint": "8.28.0",
     "eslint-config-next": "13.0.5",
     "next": "13.0.5",

--- a/ui/utils/constants.ts
+++ b/ui/utils/constants.ts
@@ -2,7 +2,7 @@
 const networkConfig = {
   Berkeley: {
     coinflipContract: {
-      publicKey: 'B62qiTeKV99ugy2JpAV1wGJ7cPGaUBBohH8MPjjGCVFdFexVmVyARHb',
+      publicKey: 'B62qjAwNeTb4YqpaNwrLmCporHJ2jRiq5xYuVdGpmwq94cke2FQtVQG',
       datastoreKey: 'berkeley-state',
     }
   },

--- a/ui/utils/datasource.ts
+++ b/ui/utils/datasource.ts
@@ -1,4 +1,4 @@
-import {Field, PublicKey} from 'snarkyjs';
+import {Field, MerkleMap, Poseidon, PublicKey} from 'snarkyjs';
 import {networkConfig} from './constants';
 
 const BASE_URL = `https://global-nice-gopher-30365.upstash.io`
@@ -13,23 +13,24 @@ interface ServerResult {
   result: null | string;
 }
 
-interface PublicKeyMerkleState {
-  balance: number;
-}
 export interface ExternalMerkleState {
-  [key: string]: PublicKeyMerkleState
+  [key: string]: string
 }
 
 
 // TODO: JB make configurable per network
-async function setMerkleValueExternally(publicKey: PublicKey, newBalance: number, isLocal: boolean): Promise<string | null> {
+async function setMerkleValueExternally(stateRootHash: string, publicKey: PublicKey, newBalance: number): Promise<string | null> {
   console.debug(`method name: setMerkleValueExternally`);
-  const existingMapFromStorage = await getMerkleValuesExternally(isLocal);
-  const updatedMap = existingMapFromStorage ? updateMap(existingMapFromStorage, publicKey, newBalance) : updateMap(null, publicKey, newBalance);
-  const networkKey = isLocal ? networkConfig.Local.coinflipContract.datastoreKey : networkConfig.Berkeley.coinflipContract.datastoreKey
-  const url = `${BASE_URL}/set/${networkKey}`;
+  const stored = await getMerkleValuesExternally(stateRootHash);
+  const map = stored[0];
+  const keys = stored[1];
+  const key = Poseidon.hash(publicKey.toFields());
+  keys.add(key);
+  map.set(key, Field(newBalance));
+  const newStateRootHash = map.getRoot();
+  const url = `${BASE_URL}/set/${newStateRootHash}`;
   console.debug(`DEV - setting state...`);
-  const result = await fetch(url, {...HEADERS, method: 'POST', body: JSON.stringify(updatedMap)});
+  const result = await fetch(url, {...HEADERS, method: 'POST', body: JSON.stringify(deserializeMap(map, keys))});
   const json  = (await result.json() as ServerResult);
   if (json.result) {
     return json.result;
@@ -39,18 +40,18 @@ async function setMerkleValueExternally(publicKey: PublicKey, newBalance: number
 }
 
 
-async function getMerkleValuesExternally(isLocal: boolean): Promise<null | ExternalMerkleState> {
+async function getMerkleValuesExternally(stateRootHash: string): Promise<[MerkleMap, Set<Field>]> {
   console.debug(`method name: getMerkleValuesExternally`);
-  const networkKey = isLocal ? networkConfig.Local.coinflipContract.datastoreKey : networkConfig.Berkeley.coinflipContract.datastoreKey
-  const url = `${BASE_URL}/get/${networkKey}`;
+  const url = `${BASE_URL}/get/${stateRootHash}`;
   const result = await fetch(url, {...HEADERS});
   const json  = (await result.json() as ServerResult);
   if (json.result) {
-    const state = parseResult(json);
-    console.debug(`DEV - reading state from get: ${state}`)
-    return state;
+    const jsonState = parseResult(json)
+    const state = serializeMap(jsonState);
+    console.debug(`DEV - reading state from get: ${jsonState}`)
+    return state
   } else {
-    return null;
+    return [new MerkleMap(), new Set()];
   }
 }
 
@@ -58,28 +59,29 @@ function parseResult(json: ServerResult): ExternalMerkleState {
   return JSON.parse(json.result as string);
 }
 
-async function determineWithdrawAmount(key: PublicKey, isLocal: boolean): Promise<Field> {
-  const stateValues = await getMerkleValuesExternally(isLocal);
-  if (stateValues) {
-    const balanceToWithdraw = stateValues[key.toBase58()].balance;
-    if (!balanceToWithdraw) {
-      throw `Could not find public key: ${key.toBase58()} in map of user balances`;
-    } else {
-      return Field(balanceToWithdraw);
-    }
-  } else {
-    // throw 'should never occur (actually can happen if I just withdraw without having deposited)';
-    return Field(0);
-  }
+function serializeMap(externalState: ExternalMerkleState): [MerkleMap, Set<Field>] {
+  console.debug(`method name: serializeMap`);
+  const serialized = new MerkleMap();
+  const merkleKeys: Set<Field> = new Set();
+  Object.keys(externalState).forEach((key) => {
+    console.debug(`Key: ${key}: ${externalState[key]}`);
+    serialized.set(Field(key), Field(externalState[key]));
+    merkleKeys.add(Field(key));
+  });
+
+  return [serialized, merkleKeys];
 }
 
-function updateMap(existingMap: ExternalMerkleState | null, publicKey: PublicKey, newBalance: number): ExternalMerkleState {
-  if (existingMap) {
-    existingMap[publicKey.toBase58()] = { balance: newBalance};
-    return existingMap;
-  } else {
-    return { [publicKey.toBase58()]: {balance: newBalance}};
-  }
+function deserializeMap(internalState: MerkleMap, keys: Set<Field>): ExternalMerkleState {
+  console.debug(`method name: deserializeMap`);
+  const deserialized: ExternalMerkleState = {};
+  
+  keys.forEach((key) => {
+    console.debug(`Key: ${key.toString()}: ${internalState.get(key).toString()}`)
+    deserialized[key.toString()] = internalState.get(key).toString();
+  });
+
+  return deserialized;
 }
 
 async function clearState() {
@@ -98,4 +100,4 @@ function generateHeaders() {
 }
 
 
-export {getMerkleValuesExternally, setMerkleValueExternally, determineWithdrawAmount, clearState};
+export {getMerkleValuesExternally, setMerkleValueExternally, clearState};


### PR DESCRIPTION
Prime: @jhhb 

+ updating contracts package version
+ adding `contractRootHash` to state, which reads from the deployed contract what the root hash is
+ adding serializer and deserializer for merkleMap to JSON
+ updating calls to redis to be keyed on the root hash, not the network
  + the implication of this is that there is more storage overall, but it is a lot more robust (not entirely robust..)
  + similar to IPFS, the address is derived from the content itself, so we should not have collisions in a meaningful way

- removed some cruft methods which we don't need
- removed the `balance` key from the serialized state type.  Just `string => string` now
- updated calls to the redis util within the zkappworker
- the new point of view is to interact directly with the merkle map as soon as we serialize it from redis
  - avoid passing around the json object representation, but you can call `deserialize` on it for UI purposes
  - I may not have followed this rule everywhere, but if not then it was an oversight
  - `merkleKeys` must be tracked so that we can deserialize the merkleMap.  The keys are stored in a Set and we only need to add one if a user injects a new key into our world.  I do that in the deposit method, not sure where else it will be needed.

In general, I didn't think through edge cases or error states.  I just went with "this should work".  Definitely call out anything that looks fishy.  I'm only marginally acquainted with this app.

**Using this branch, I successfully withdrew my stake! [check it out](https://berkeley.minaexplorer.com/transaction/CkpZBVyYE6EpWDtBD2JrtsJK8BbnHUPqoUakNmPS9fF3tWeixNkdU)** - one failed tx on the contract was to get state synced up with my transaction from the CLI.  Then after state was synced I was able to withdraw!