### PR TITLE
moving boxes around

### DIFF
--- a/ui/components/MainContent.tsx
+++ b/ui/components/MainContent.tsx
@@ -142,7 +142,7 @@ export class MainContent extends React.Component<Props, State> {
       } catch (err) {
         throw err;
       } finally {
-        this.setState({ awaiting: false });
+        this.setState({ awaiting: false, magnitude: Int64.from(0) });
       }
     }
   };

--- a/ui/components/MainContent.tsx
+++ b/ui/components/MainContent.tsx
@@ -1,5 +1,5 @@
 import { networkConfig } from "../utils/constants";
-import { makeAccountUrl } from "../utils/minascan";
+import { makeAccountUrl } from "../utils/minaexplorer";
 import * as styles from "./MainContent.module.css";
 import * as React from "react";
 import {Int64, PrivateKey, PublicKey} from "snarkyjs";
@@ -200,7 +200,7 @@ export class MainContent extends React.Component<Props, State> {
             <LoadableButton
               disabled={awaiting}
               onClick={this.handleFlipCoin}
-              text={"Flip Coin"}
+              text={"Flip Coin (costs 5 tokens)"}
               loading={buttonsAreLoading || awaiting}
             />
           </Button.Group>
@@ -208,7 +208,7 @@ export class MainContent extends React.Component<Props, State> {
             <LoadableButton
               onClick={this.handleDeposit}
               disabled={awaiting}
-              text={"Deposit 0.000001 Mina"}
+              text={"Deposit 1000 Tokens Collateral"}
               loading={buttonsAreLoading || awaiting}
             />
             <LoadableButton
@@ -234,11 +234,23 @@ export class MainContent extends React.Component<Props, State> {
           </Button.Group>
         </div>
         <Spacer />
+        <Text h3>ZK App (on-chain) and Local (off-chain) states</Text>
+        <LocalUiState
+          userState={this.state.userState}
+          loading={buttonsAreLoading}
+          magnitude={this.state.magnitude}
+          renderMagnitude={true}
+        />
+        <OnChainUiState
+          state={this.state.appState}
+          loading={buttonsAreLoading}
+        />
+        <Spacer />
         <Text h3>Mina Account Balances</Text>
         {this.state.zkAppBalance ? (
           <Balance
             balance={this.state.zkAppBalance}
-            label="ZK App Account balance"
+            label="ZK App Mina balance"
           />
         ) : (
           <div>
@@ -250,7 +262,7 @@ export class MainContent extends React.Component<Props, State> {
         {this.state.userBalance ? (
           <Balance
             balance={this.state.userBalance}
-            label="User account balance"
+            label="User Mina balance"
           />
         ) : (
           <div>
@@ -259,18 +271,6 @@ export class MainContent extends React.Component<Props, State> {
           </div>
         )}
         <Spacer />
-        <Text h3>ZK App (on-chain) and Local (off-chain) states</Text>
-        <OnChainUiState
-          state={this.state.appState}
-          loading={buttonsAreLoading}
-        />
-        <Spacer />
-        <LocalUiState
-          userState={this.state.userState}
-          loading={buttonsAreLoading}
-          magnitude={this.state.magnitude}
-          renderMagnitude={true}
-        />
       </div>
     );
   }
@@ -311,7 +311,7 @@ function MerkleStateUi(props: MerkleStateUiProps) {
           <div>Your Account Hash: {props.merkleKey?.slice(0, 10)}...</div>
           <b>
             <div>Your Collateral: {props.merkleValue}</div>
-            {props.renderMagnitude && <div>Winnings/Losses for this session: {formattedMagnitude} millionths of a Mina</div>}
+            {props.renderMagnitude && <div>Winnings/Losses for this session: {formattedMagnitude} tokens</div>}
           </b>
         </Card.Body>
         <Card.Footer>
@@ -385,7 +385,7 @@ function OnChainUiState(props: OnChainUiState) {
       renderMagnitude={false}
       rightSideHeaderContent={
         <StyledLink href={makeAccountUrl(networkConfig.BERKELEY.coinflipContract.publicKey)}>
-          Check out the contract on minascan.io
+          Check out the contract on Mina Explorer
         </StyledLink>
       }
     />

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -13,7 +13,7 @@
         "@types/react": "18.0.25",
         "@types/react-dom": "18.0.9",
         "coi-serviceworker": "^0.1.6",
-        "coinflip-executor-contract": "0.5.2",
+        "coinflip-executor-contract": "0.5.3",
         "dotenv": "^16.0.3",
         "eslint": "8.28.0",
         "eslint-config-next": "13.0.5",
@@ -2036,9 +2036,9 @@
       "integrity": "sha512-STWJBMdxuKvvzbd3G1+sFrV5Ia+UDv5lP2CVCx+kEfqghOSb8nzcG/ttpSV2k/haTUn5OsfTAlkK+uFkKBqBqw=="
     },
     "node_modules/coinflip-executor-contract": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/coinflip-executor-contract/-/coinflip-executor-contract-0.5.2.tgz",
-      "integrity": "sha512-cD/x32ownyvoRkmA3kNvQGerOYRduSnx3DU41cgYgcTQ3tvsMPUXkJAf1r9QNBaCJNehw6zi085UQZ4rs+NYWw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/coinflip-executor-contract/-/coinflip-executor-contract-0.5.3.tgz",
+      "integrity": "sha512-jYf4oCxOcNvfNqiCmS+sL9lZlOzShTUak0VRI7SyUJdCnxrZIfsJC0fCXi6U7jJ1PtPc299jYeAmXRzfIZ3NfA==",
       "peerDependencies": {
         "snarkyjs": "^0.7.3"
       }
@@ -5959,9 +5959,9 @@
       "integrity": "sha512-STWJBMdxuKvvzbd3G1+sFrV5Ia+UDv5lP2CVCx+kEfqghOSb8nzcG/ttpSV2k/haTUn5OsfTAlkK+uFkKBqBqw=="
     },
     "coinflip-executor-contract": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/coinflip-executor-contract/-/coinflip-executor-contract-0.5.2.tgz",
-      "integrity": "sha512-cD/x32ownyvoRkmA3kNvQGerOYRduSnx3DU41cgYgcTQ3tvsMPUXkJAf1r9QNBaCJNehw6zi085UQZ4rs+NYWw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/coinflip-executor-contract/-/coinflip-executor-contract-0.5.3.tgz",
+      "integrity": "sha512-jYf4oCxOcNvfNqiCmS+sL9lZlOzShTUak0VRI7SyUJdCnxrZIfsJC0fCXi6U7jJ1PtPc299jYeAmXRzfIZ3NfA==",
       "requires": {}
     },
     "color-convert": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,7 +17,7 @@
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.9",
     "coi-serviceworker": "^0.1.6",
-    "coinflip-executor-contract": "0.5.2",
+    "coinflip-executor-contract": "0.5.3",
     "dotenv": "^16.0.3",
     "eslint": "8.28.0",
     "eslint-config-next": "13.0.5",

--- a/ui/pages/_app.page.tsx
+++ b/ui/pages/_app.page.tsx
@@ -50,6 +50,7 @@ export default function App() {
 
       if (shouldRun) {
         if (NETWORK === "BERKELEY" || NETWORK === "LOCAL") {
+          await zkappWorkerClient.loadSnarkyJS();
           const setupState = await setupNetwork(
             NETWORK,
             zkappWorkerClient,

--- a/ui/pages/zkappWorker.ts
+++ b/ui/pages/zkappWorker.ts
@@ -387,6 +387,16 @@ const functions = {
     // from CD: after a successful withdrawal, we set to 0.
     state.map.set(key, Field(0));
     await setMerkleValueExternally(state.contractRootHash, userPublicKey, 0);
+    state.channelBalance!.deltaBalance = Int64.from(0);
+    state.channelBalance!.nonce = Field(0);
+    state.latestSignedChannelBalance = Signature.create(
+      PrivateKey.fromBase58(process.env.EXECUTOR_PRIVATE_KEY!),
+      [
+        Poseidon.hash(userPublicKey.toFields()),
+        state.channelBalance!.deltaBalance.toField(),
+        state.channelBalance!.nonce,
+      ]
+    );
   },
   flipCoin: async (args: {
     userPrivateKey58: string;

--- a/ui/utils/constants.ts
+++ b/ui/utils/constants.ts
@@ -2,7 +2,7 @@ const networkConfig = {
   currentNetwork: process.env.APP_NETWORK,
   BERKELEY: {
     coinflipContract: {
-      publicKey: 'B62qmgSt4XncvYid6w7rFVtBs1Pj295sw62ARfpq4zJ6td9hrLmJzmk',
+      publicKey: 'B62qjroK2cjbPeLoPnVaX6EoHPEMcWP7pfhuG4rVXgzA9WRiC7tKGGZ',
       datastoreKey: 'berkeley-state',
     },
     oracleUrl:

--- a/ui/utils/minaexplorer.ts
+++ b/ui/utils/minaexplorer.ts
@@ -1,0 +1,6 @@
+function makeAccountUrl(publicKey58: string | null): string {
+  return `https://berkeley.minaexplorer.com/wallet/${publicKey58 || 'no-contract-address'}`;
+}
+
+
+export {makeAccountUrl}

--- a/ui/utils/minascan.ts
+++ b/ui/utils/minascan.ts
@@ -1,8 +1,0 @@
-import {PublicKey} from 'snarkyjs';
-
-function makeAccountUrl(publicKey58: string | null): string {
-  return `https://minascan.io/berkeley/account/${publicKey58 || 'no-contract-address'}/zkApp?limit=50&orderBy=ASC&page=0&sortBy=fee`;
-}
-
-
-export {makeAccountUrl}


### PR DESCRIPTION
Prime: @jhhb 

I'm moving the relevant user state to the top.

I thought the millionth of a mina stuff was too wordy.  I just subbed out for "tokens", and added to the coin flip that it costs 5 tokens.  I also subbed out minascan for mina explorer.  Scan wasn't showing me zkapp transactions.

Finally, I fixed a mini bug where the player still has a channel balance after withdraw.  That was my bad.  Doing some local dev to confirm this fix.